### PR TITLE
Add danbooru integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ An async Booru client for Rust
 The client currently supports:
 - [x] Gelbooru
 - [ ] Safebooru
-- [ ] Danbooru
+- [x] Danbooru
 - [ ] Konachan
 - [ ] R34
 - [ ] 3DBooru

--- a/src/client/danbooru/mod.rs
+++ b/src/client/danbooru/mod.rs
@@ -1,0 +1,113 @@
+use reqwest::Client;
+
+use crate::model::danbooru::*;
+
+/// Client that sends requests to the Danbooru API to retrieve the data.
+#[allow(dead_code)]
+pub struct DanbooruClient {
+    client: Client,
+    key: Option<String>
+}
+
+impl DanbooruClient {
+    pub fn builder() -> DanbooruClientBuilder {
+        DanbooruClientBuilder::default()
+    }
+}
+
+/// Builder for [`DanbooruClient`]
+#[derive(Default)]
+pub struct DanbooruClientBuilder {
+    client: Client,
+    key: Option<String>,
+    user: Option<String>,
+    tags: Vec<String>,
+    limit: u32,
+}
+
+impl DanbooruClientBuilder {
+    pub fn new() -> DanbooruClientBuilder {
+        DanbooruClientBuilder {
+            client: Client::new(),
+            key: None,
+            user: None,
+            tags: vec![],
+            limit: 100,
+        }
+    }
+    /// Set the API key and User for the requests (optional)
+    pub fn set_credentials(mut self, key: String, user: String) -> Self {
+        self.key = Some(key);
+        self.user = Some(user);
+        self
+    }
+
+    /// Add a tag to the query
+    pub fn tag(mut self, tag: String) -> Self {
+        self.tags.push(tag);
+        self
+    }
+
+    /// Add a [`DanbooruRating`] to the query
+    pub fn rating(mut self, rating: DanbooruRating) -> Self {
+        self.tags.push(format!("rating:{}", rating));
+        self
+    }
+
+    /// Set how many posts you want to retrieve (100 is the default and maximum)
+    pub fn limit(mut self, limit: u32) -> Self {
+        self.limit = limit;
+        self
+    }
+
+    /// Retrieves the posts in a random order
+    pub fn random(mut self, random: bool) -> Self {
+        if random {
+            self.tags.push("order:random".to_string());
+        }
+        self
+    }
+
+    /// Add a [`DanbooruSort`] to the query
+    pub fn sort(mut self, order: DanbooruSort) -> Self {
+        self.tags.push(format!("order:{}", order));
+        self
+    }
+
+    /// Blacklist a tag from the query
+    pub fn blacklist_tag(mut self, tag: String) -> Self {
+        self.tags.push(format!("-{tag}"));
+        self
+    }
+
+    /// Directly get a post by its unique Id
+    pub async fn get_by_id(&self, id: u32) -> Result<DanbooruPost, reqwest::Error> {
+        let response = self.client
+            .get(format!("https://danbooru.donmai.us/posts/{id}.json"))
+            .send()
+            .await?
+            .json::<DanbooruPost>()
+            .await?;
+
+        Ok(response)
+    }
+
+    /// Pack the [`DanbooruClientBuilder`] and sent the request to the API to retrieve the posts
+    pub async fn get(&self) -> Result<Vec<DanbooruPost>, reqwest::Error> {
+        let tag_string = self.tags.join(" ");
+        let response = self.client
+            .get("https://danbooru.donmai.us/posts.json")
+            .query(&[
+                ("limit", self.limit.to_string().as_str()),
+                ("tags", &tag_string),
+            ])
+            .send()
+            .await?
+            .json::<Vec<DanbooruPost>>()
+            .await?;
+
+        println!("{response:#?}");
+
+        Ok(response)
+    }
+}

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,1 +1,2 @@
 pub mod gelbooru;
+pub mod danbooru;

--- a/src/model/danbooru.rs
+++ b/src/model/danbooru.rs
@@ -50,7 +50,7 @@ pub struct DanbooruPost {
     pub bit_flags: u32,
 }
 
-/// Post's rating. Check the [Danbooru's ratings wiki](https://danbooru.com/index.php?page=help&topic=rating)
+/// Post's rating. Check the [Danbooru's ratings wiki](https://danbooru.donmai.us/wiki_pages/howto:rate)
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "lowercase")]
 pub enum DanbooruRating {

--- a/src/model/danbooru.rs
+++ b/src/model/danbooru.rs
@@ -1,0 +1,87 @@
+//! Models for Danbooru
+use core::fmt;
+
+use serde::{Serialize, Deserialize};
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct DanbooruPost {
+    pub id: u32,
+    pub created_at: String,
+    pub updated_at: String,
+    pub uploader_id: u32,
+    pub approver_id: Option<u32>,
+    pub tag_string: String,
+    pub tag_string_general: String,
+    pub tag_string_artist: String,
+    pub tag_string_copyright: String,
+    pub tag_string_character: String,
+    pub tag_string_meta: String,
+    pub rating: Option<DanbooruRating>,
+    pub parent_id: Option<u32>,
+    pub pixiv_id: Option<u32>,
+    pub source: String,
+    pub md5: Option<String>,
+    pub file_url: Option<String>,
+    pub large_file_url: Option<String>,
+    pub preview_file_url: Option<String>,
+    pub file_ext: String,
+    pub file_size: u32,
+    pub image_width: u32,
+    pub image_height: u32,
+    pub score: u32,
+    pub up_score: u32,
+    pub down_score: u32,
+    pub fav_count: u32,
+    pub tag_count_general: u32,
+    pub tag_count_artist: u32,
+    pub tag_count_copyright: u32,
+    pub tag_count_character: u32,
+    pub tag_count_meta: u32,
+    pub last_comment_bumped_at: Option<String>,
+    pub last_noted_at: Option<String>,
+    pub has_large: bool,
+    pub has_children: bool,
+    pub has_visible_children: bool,
+    pub has_active_children: bool,
+    pub is_banned: bool,
+    pub is_deleted: bool,
+    pub is_flagged: bool,
+    pub is_pending: bool,
+    pub bit_flags: u32,
+}
+
+/// Post's rating. Check the [Danbooru's ratings wiki](https://danbooru.com/index.php?page=help&topic=rating)
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "lowercase")]
+pub enum DanbooruRating {
+    E,
+    Q,
+    S,
+    G,
+}
+
+impl fmt::Display for DanbooruRating {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let lowercase_tag = format!("{:?}", self).to_lowercase();
+        write!(f, "{lowercase_tag}")
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum DanbooruSort {
+    Id,
+    Score,
+    Rating,
+    User,
+    Height,
+    Width,
+    Source,
+    Updated
+}
+
+impl fmt::Display for DanbooruSort {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let lowercase_tag = format!("{:?}", self).to_lowercase();
+        write!(f, "{lowercase_tag}")
+    }
+}

--- a/src/model/danbooru.rs
+++ b/src/model/danbooru.rs
@@ -54,10 +54,14 @@ pub struct DanbooruPost {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "lowercase")]
 pub enum DanbooruRating {
-    E,
-    Q,
-    S,
-    G,
+    #[serde(rename = "e")]
+    Explicit,
+    #[serde(rename = "q")]
+    Questionable,
+    #[serde(rename = "s")]
+    Sensitive,
+    #[serde(rename = "g")]
+    General,
 }
 
 impl fmt::Display for DanbooruRating {

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,1 +1,2 @@
 pub mod gelbooru;
+pub mod danbooru;

--- a/tests/danbooru_tests.rs
+++ b/tests/danbooru_tests.rs
@@ -15,7 +15,7 @@ async fn get_posts_with_tag() {
 async fn get_posts_with_rating() {
     let posts = DanbooruClient::builder()
         .tag("kafuu_chino".to_string())
-        .rating(DanbooruRating::G)
+        .rating(DanbooruRating::General)
         .get()
         .await;
 
@@ -39,7 +39,7 @@ async fn get_posts_with_sort() {
 async fn get_posts_with_blacklist_tag() {
     let posts = DanbooruClient::builder()
         .tag("kafuu_chino".to_string())
-        .blacklist_tag(DanbooruRating::E.to_string())
+        .blacklist_tag(DanbooruRating::Explicit.to_string())
         .get()
         .await;
 
@@ -51,7 +51,7 @@ async fn get_posts_with_blacklist_tag() {
 async fn get_posts_with_limit() {
     let posts = DanbooruClient::builder()
         .tag("kafuu_chino".to_string())
-        .rating(DanbooruRating::G)
+        .rating(DanbooruRating::General)
         .limit(3)
         .get()
         .await;
@@ -97,10 +97,10 @@ async fn get_post_by_id() {
 
 #[test]
 fn parse_rating_tags() {
-    assert_eq!("e", DanbooruRating::E.to_string());
-    assert_eq!("q", DanbooruRating::Q.to_string());
-    assert_eq!("s", DanbooruRating::S.to_string());
-    assert_eq!("g", DanbooruRating::G.to_string());
+    assert_eq!("explicit", DanbooruRating::Explicit.to_string());
+    assert_eq!("questionable", DanbooruRating::Questionable.to_string());
+    assert_eq!("sensitive", DanbooruRating::Sensitive.to_string());
+    assert_eq!("general", DanbooruRating::General.to_string());
 }
 
 #[test]

--- a/tests/danbooru_tests.rs
+++ b/tests/danbooru_tests.rs
@@ -1,0 +1,116 @@
+use booru_rs::{client::danbooru::DanbooruClient, model::danbooru::{DanbooruRating, DanbooruSort}};
+
+#[tokio::test]
+async fn get_posts_with_tag() {
+    let posts = DanbooruClient::builder()
+        .tag("kafuu_chino".to_string())
+        .get()
+        .await;
+
+    assert!(posts.is_ok());
+    assert_eq!(true, posts.unwrap().len() > 0);
+}
+
+#[tokio::test]
+async fn get_posts_with_rating() {
+    let posts = DanbooruClient::builder()
+        .tag("kafuu_chino".to_string())
+        .rating(DanbooruRating::G)
+        .get()
+        .await;
+
+    assert!(posts.is_ok());
+    assert_eq!(true, posts.unwrap().len() > 0);
+}
+
+#[tokio::test]
+async fn get_posts_with_sort() {
+    let posts = DanbooruClient::builder()
+        .tag("kafuu_chino".to_string())
+        .sort(DanbooruSort::Score)
+        .get()
+        .await;
+
+    assert!(posts.is_ok());
+    assert_eq!(true, posts.unwrap().len() > 0);
+}
+
+#[tokio::test]
+async fn get_posts_with_blacklist_tag() {
+    let posts = DanbooruClient::builder()
+        .tag("kafuu_chino".to_string())
+        .blacklist_tag(DanbooruRating::E.to_string())
+        .get()
+        .await;
+
+    assert!(posts.is_ok());
+    assert_eq!(true, posts.unwrap().len() > 0);
+}
+
+#[tokio::test]
+async fn get_posts_with_limit() {
+    let posts = DanbooruClient::builder()
+        .tag("kafuu_chino".to_string())
+        .rating(DanbooruRating::G)
+        .limit(3)
+        .get()
+        .await;
+
+    assert!(posts.is_ok());
+    assert_eq!(true, posts.unwrap().len() == 3);
+}
+
+#[tokio::test]
+async fn get_posts_multiple_tags() {
+    let posts = DanbooruClient::builder()
+        .tag("kafuu_chino".to_string())
+        .tag("bangs".to_string())
+        .limit(3)
+        .get()
+        .await;
+
+    assert!(posts.is_ok());
+    assert_eq!(true, posts.unwrap().len() > 0);
+}
+
+#[tokio::test]
+async fn get_random_posts() {
+    let posts = DanbooruClient::builder()
+        .tag("kafuu_chino".to_string())
+        .random(true)
+        .get()
+        .await;
+
+    assert!(posts.is_ok());
+    assert_eq!(true, posts.unwrap().len() > 0);
+}
+
+#[tokio::test]
+async fn get_post_by_id() {
+    let post = DanbooruClient::builder()
+        .get_by_id(5817461)
+        .await;
+
+    assert!(post.is_ok());
+    assert_eq!("569b8df8a16d7b42b4c244bfa0b6a838", post.unwrap().md5.unwrap());
+}
+
+#[test]
+fn parse_rating_tags() {
+    assert_eq!("e", DanbooruRating::E.to_string());
+    assert_eq!("q", DanbooruRating::Q.to_string());
+    assert_eq!("s", DanbooruRating::S.to_string());
+    assert_eq!("g", DanbooruRating::G.to_string());
+}
+
+#[test]
+fn parse_sort_tags() {
+    assert_eq!("id", DanbooruSort::Id.to_string());
+    assert_eq!("score", DanbooruSort::Score.to_string());
+    assert_eq!("rating", DanbooruSort::Rating.to_string());
+    assert_eq!("user", DanbooruSort::User.to_string());
+    assert_eq!("height", DanbooruSort::Height.to_string());
+    assert_eq!("width", DanbooruSort::Width.to_string());
+    assert_eq!("source", DanbooruSort::Source.to_string());
+    assert_eq!("updated", DanbooruSort::Updated.to_string());
+}


### PR DESCRIPTION
Implement Danbooru

I am still learning rust, so it might not be very good, and it might make sense to create traits and so on to have a standard interface. E.g. the only real difference between Danbooru and Safebooru is the URL. But I am not well enough versed in rust yet to implement traits etc. Additionally, there is the `DanbooruRating` class enum that atm uses single letter field names as this is what the API returns, but I guess it's possible with `Serde` to make it so that you have readable names but match the single letter fields in the API - I just don't know how yet. 

Please do tell me about any improvements, as I am pretty eager to learn rust. 

- [x] Basic Danbooru implementation
- [x] Readable / Usable ratings instead of a single letter
- [ ] Common interface for Danbooru / Safebooru (and other that may use the same API)
